### PR TITLE
Add .env.example instructions and clean up route types

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# Tigris credentials retrieved here: https://console.tigris.dev/
 TIGRIS_STORAGE_ACCESS_KEY_ID=
 TIGRIS_STORAGE_SECRET_ACCESS_KEY=
 TIGRIS_STORAGE_BUCKET=

--- a/src/app/api/files/[id]/route.ts
+++ b/src/app/api/files/[id]/route.ts
@@ -1,19 +1,26 @@
 import { getPresignedUrl, remove } from "@tigrisdata/storage";
 import { NextRequest, NextResponse } from "next/server";
 
-type Params = { params: Promise<{ id: string }> };
-
-export async function GET(_request: NextRequest, { params }: Params) {
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id } = await params;
   const key = decodeURIComponent(id);
   const response = await getPresignedUrl(key, { method: "get" });
   if (response.error) {
-    return NextResponse.json({ error: response.error.message }, { status: 500 });
+    return NextResponse.json(
+      { error: response.error.message },
+      { status: 500 }
+    );
   }
   return NextResponse.json({ url: response.data.url });
 }
 
-export async function DELETE(_request: NextRequest, { params }: Params) {
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id } = await params;
   const key = decodeURIComponent(id);
   await remove(key);


### PR DESCRIPTION
## Summary
- Added credential retrieval comment with dashboard link to `.env.example` (required for Vercel template submission)
- Removed separate `Params` type alias, inlined params type in route handlers

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)