### PR TITLE
chore: address Bugbot feedback on renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,11 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
     ":semanticCommitTypeAll(chore)"
   ],
   "timezone": "UTC",
-  "schedule": ["before 9am on monday"],
+  "schedule": ["* 0-8 * * 1"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": ["dependencies"],


### PR DESCRIPTION
## Summary

Follow-up to #5 (the Renovate onboarding PR), which was merged before the Bugbot review feedback landed. Applies the same two fixes already pushed to mcp-oidc-provider, mcp, and agent-shell.

- **Cron syntax** — Renovate has deprecated later.js text in favor of cron. `"before 9am on monday"` → `"* 0-8 * * 1"` (any minute, hours 0–8 UTC, Mondays).
- **Drop redundant preset** — `:dependencyDashboard` is already bundled inside `config:recommended`; explicit listing was clutter.

No behavioral change; only forward-compatibility and clarity.

## Test plan

- [ ] Renovate next-run interprets the cron schedule and produces the weekly non-major dependencies PR
- [ ] No deprecation warning in Renovate logs
- [ ] Dependency Dashboard issue still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)