### PR TITLE
chore: enable OSV alerts and restore bi-weekly major cadence

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "labels": ["dependencies"],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "schedule": ["at any time"]
+  },
   "packageRules": [
     {
       "description": "Bundle all minor and patch updates (npm, GitHub Actions, Docker) into a single weekly PR",

--- a/renovate.json
+++ b/renovate.json
@@ -20,10 +20,11 @@
       "groupName": "non-major dependencies"
     },
     {
-      "description": "Major dependency updates: bundled, only after 14 days of release age (~bi-weekly cadence)",
+      "description": "Major dependency updates: bundled, bi-weekly cadence (first and third Monday) with a 14-day staleness floor",
       "matchUpdateTypes": ["major"],
       "groupName": "major dependencies",
-      "minimumReleaseAge": "14 days"
+      "minimumReleaseAge": "14 days",
+      "schedule": ["* 0-5 1-7,15-21 * 1"]
     },
     {
       "description": "TypeScript and @types/node major updates: held 60 days post-release (~every 2 months)",


### PR DESCRIPTION
## Summary

Two related Renovate tweaks bundled together:

### 1. Enable OSV vulnerability alerts
- `osvVulnerabilityAlerts: true` — checks the OSV (Open Source Vulnerabilities) database in addition to GitHub Advisory
- `vulnerabilityAlerts.schedule: ["at any time"]` — security PRs bypass the regular weekly Monday window so fixes can open immediately

### 2. Restore strict bi-weekly cadence for major updates
- Add `schedule: ["* 0-5 1-7,15-21 * 1"]` to the bundled "major dependencies" rule
- Matches the first and third Monday of each month (days 1–7 and 15–21) — exactly 14 days apart
- Previously `minimumReleaseAge: "14 days"` alone only enforced a staleness floor; the bundled major PR could refresh weekly. With the cron, it refreshes truly bi-weekly, matching the original "every 2 weeks" intent.

## Test plan

- [ ] Dependency Dashboard regenerates and shows a "Vulnerabilities" section if any apply
- [ ] Next Renovate run logs no schema errors
- [ ] The "major dependencies" PR only refreshes on first/third Monday going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)